### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@ ThreadFix is developed and maintained by Denim Group, Ltd (http://www.denimgroup
 		<codehaus.jackson.version>1.6.2</codehaus.jackson.version>
 		<cglib.version>2.2.2</cglib.version>
 		<commons.beanutils.version>1.8.3</commons.beanutils.version>
-		<commons.collections.version>3.2.1</commons.collections.version>
+		<commons.collections.version>3.2.2</commons.collections.version>
 		<commons.digester.version>1.8.1</commons.digester.version>
 		<commons.fileupload.version>1.2.2</commons.fileupload.version>
 		<commons.httpclient.version>3.1</commons.httpclient.version>

--- a/target/m2e-wtp/web-resources/META-INF/maven/com.denimgroup/threadfix/pom.xml
+++ b/target/m2e-wtp/web-resources/META-INF/maven/com.denimgroup/threadfix/pom.xml
@@ -496,7 +496,7 @@ ThreadFix is developed and maintained by Denim Group, Ltd (http://www.denimgroup
 		<codehaus.jackson.version>1.6.2</codehaus.jackson.version>
 		<cglib.version>2.2.2</cglib.version>
 		<commons.beanutils.version>1.8.3</commons.beanutils.version>
-		<commons.collections.version>3.2.1</commons.collections.version>
+		<commons.collections.version>3.2.2</commons.collections.version>
 		<commons.digester.version>1.8.1</commons.digester.version>
 		<commons.fileupload.version>1.2.2</commons.fileupload.version>
 		<commons.httpclient.version>3.1</commons.httpclient.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
